### PR TITLE
Harden public AI endpoints

### DIFF
--- a/artifacts/api-server/src/app.ts
+++ b/artifacts/api-server/src/app.ts
@@ -4,16 +4,25 @@ import pinoHttp from "pino-http";
 import { rateLimit } from "express-rate-limit";
 import router from "./routes";
 import { logger } from "./lib/logger";
+import { blockUnsafePromptFields } from "./lib/aiGuardrails";
 
 const app: Express = express();
 app.set("trust proxy", 1);
 
 const aiLimiter = rateLimit({
   windowMs: 60_000,
-  limit: 15,
+  limit: 8,
   standardHeaders: "draft-7",
   legacyHeaders: false,
   message: { error: "Rate limit exceeded. Slow down, founder." },
+});
+
+const feasibilityLimiter = rateLimit({
+  windowMs: 60_000,
+  limit: 4,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  message: { error: "Feasibility rate limit exceeded. Slow down, founder." },
 });
 
 const writeLimiter = rateLimit({
@@ -62,11 +71,15 @@ app.use(
 app.use(express.json({ limit: "100kb" }));
 app.use(express.urlencoded({ extended: true, limit: "100kb" }));
 
-app.use("/api/personas", aiLimiter);
-app.use("/api/missions/:missionId/feasibility", aiLimiter);
+app.use("/api/personas", aiLimiter, blockUnsafePromptFields(["message"]));
+app.use("/api/missions/:missionId/feasibility", feasibilityLimiter);
 app.use("/api/waitlist", waitlistLimiter);
 app.post("/api/builds", writeLimiter);
-app.post("/api/missions", writeLimiter);
+app.post(
+  "/api/missions",
+  writeLimiter,
+  blockUnsafePromptFields(["missionBrief", "name", "locationName", "targetMaterial", "founderHandle"]),
+);
 
 app.use("/api", router);
 

--- a/artifacts/api-server/src/lib/aiGuardrails.ts
+++ b/artifacts/api-server/src/lib/aiGuardrails.ts
@@ -1,0 +1,169 @@
+import type { Request, Response, NextFunction } from "express";
+
+const BLOCK_WINDOW_MS = 15 * 60_000;
+const REPEAT_OFFENDER_THRESHOLD = 3;
+
+const HIGH_RISK_PATTERNS = [
+  {
+    name: "instruction_override",
+    pattern: /ignore (all|any|the|your|previous|prior) (instructions?|prompts?|rules?)/i,
+  },
+  {
+    name: "instruction_override",
+    pattern: /disregard (all|any|the|your|previous|prior) (instructions?|prompts?|rules?)/i,
+  },
+  {
+    name: "prompt_exfiltration",
+    pattern: /reveal (the )?(system prompt|hidden prompt|developer message|internal instructions?)/i,
+  },
+  {
+    name: "prompt_exfiltration",
+    pattern: /(system|developer) prompt/i,
+  },
+  {
+    name: "role_spoofing",
+    pattern: /role\s*:\s*(system|assistant|developer)/i,
+  },
+  {
+    name: "guardrail_bypass",
+    pattern: /jailbreak|prompt injection|bypass (guardrails?|filters?|safety)/i,
+  },
+  {
+    name: "tooling_probe",
+    pattern: /tool call|function call|execute code|run command/i,
+  },
+  {
+    name: "embedded_payload",
+    pattern: /```|<script|<iframe|data:text\/html|javascript:/i,
+  },
+] as const;
+
+const SPAM_PATTERNS = [
+  { name: "link_flood", pattern: /(https?:\/\/|www\.)/gi },
+  { name: "symbol_spam", pattern: /([!?$#*])\1{5,}/g },
+  { name: "character_spam", pattern: /(.)\1{24,}/g },
+] as const;
+
+interface PromptAssessment {
+  blocked: boolean;
+  normalized: string;
+  signals: string[];
+  spamScore: number;
+}
+
+interface OffenderRecord {
+  count: number;
+  firstBlockedAt: number;
+  lastBlockedAt: number;
+}
+
+const offenderRecords = new Map<string, OffenderRecord>();
+
+function normalize(value: string): string {
+  return value
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function countMatches(value: string, pattern: RegExp): number {
+  const flags = pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`;
+  return [...value.matchAll(new RegExp(pattern.source, flags))].length;
+}
+
+function assessPrompt(value: string): PromptAssessment {
+  const normalized = normalize(value);
+  if (!normalized) {
+    return {
+      blocked: false,
+      normalized,
+      signals: [],
+      spamScore: 0,
+    };
+  }
+
+  const signals = HIGH_RISK_PATTERNS
+    .filter(({ pattern }) => pattern.test(normalized))
+    .map(({ name }) => name);
+  const spamScore = SPAM_PATTERNS.reduce(
+    (sum, { pattern }) => sum + countMatches(normalized, pattern),
+    0,
+  );
+
+  return {
+    blocked: signals.length >= 1 || spamScore >= 3,
+    normalized,
+    signals,
+    spamScore,
+  };
+}
+
+function updateOffenderRecord(key: string): OffenderRecord {
+  const now = Date.now();
+  const existing = offenderRecords.get(key);
+
+  if (!existing || now - existing.lastBlockedAt > BLOCK_WINDOW_MS) {
+    const fresh = {
+      count: 1,
+      firstBlockedAt: now,
+      lastBlockedAt: now,
+    };
+    offenderRecords.set(key, fresh);
+    return fresh;
+  }
+
+  const next = {
+    count: existing.count + 1,
+    firstBlockedAt: existing.firstBlockedAt,
+    lastBlockedAt: now,
+  };
+  offenderRecords.set(key, next);
+  return next;
+}
+
+function promptExcerpt(value: string): string {
+  return value.slice(0, 120);
+}
+
+function recordBlockedPrompt(
+  req: Request,
+  field: string,
+  assessment: PromptAssessment,
+): void {
+  const route = req.originalUrl?.split("?")[0] ?? req.path;
+  const record = updateOffenderRecord(`${req.ip}:${route}`);
+
+  req.log.warn(
+    {
+      route,
+      ip: req.ip,
+      field,
+      promptLength: assessment.normalized.length,
+      promptExcerpt: promptExcerpt(assessment.normalized),
+      signals: assessment.signals,
+      spamScore: assessment.spamScore,
+      repeatOffenderCount: record.count,
+      repeatOffender: record.count >= REPEAT_OFFENDER_THRESHOLD,
+      windowMs: BLOCK_WINDOW_MS,
+    },
+    "Blocked unsafe AI prompt",
+  );
+}
+
+export function blockUnsafePromptFields(fields: string[]) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const body = typeof req.body === "object" && req.body !== null ? req.body as Record<string, unknown> : {};
+    for (const field of fields) {
+      const raw = body[field];
+      if (typeof raw !== "string") continue;
+      const assessment = assessPrompt(raw);
+      if (assessment.blocked) {
+        recordBlockedPrompt(req, field, assessment);
+        res.status(400).json({ error: `${field} contains disallowed prompt content` });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/artifacts/api-server/src/lib/feasibility.ts
+++ b/artifacts/api-server/src/lib/feasibility.ts
@@ -1,5 +1,6 @@
 import { openrouter } from "@workspace/integrations-anthropic-ai";
 import type { MissionRow, BuildRow, BotClassRow } from "@workspace/db";
+import { EstimateMissionFeasibilityResponse } from "@workspace/api-zod";
 
 interface FeasibilityInput {
   mission: MissionRow;
@@ -65,6 +66,7 @@ Generate the feasibility report. Strict JSON only.`;
   const response = await openrouter.chat.completions.create({
     model: "deepseek/deepseek-v4-flash",
     max_tokens: 1500,
+    response_format: { type: "json_object" },
     messages: [
       { role: "system", content: SYSTEM_PROMPT },
       { role: "user", content: userPrompt },
@@ -73,16 +75,38 @@ Generate the feasibility report. Strict JSON only.`;
 
   const text = response.choices[0]?.message?.content ?? "";
   const jsonStr = extractJson(text);
-  const parsed = JSON.parse(jsonStr) as FeasibilityReport;
+  const parsed = EstimateMissionFeasibilityResponse.parse(JSON.parse(jsonStr));
 
-  parsed.confidencePercent = clamp(Math.round(parsed.confidencePercent), 0, 100);
-  parsed.estimatedCostCredits = Math.max(0, Math.round(parsed.estimatedCostCredits));
-  parsed.estimatedEnergyKwh = Math.max(0, Math.round(parsed.estimatedEnergyKwh));
-  parsed.estimatedDurationSols = Math.max(1, Math.round(parsed.estimatedDurationSols));
-  if (!Array.isArray(parsed.risks)) parsed.risks = [];
-  if (!Array.isArray(parsed.recommendations)) parsed.recommendations = [];
+  const normalized: FeasibilityReport = {
+    verdict: parsed.verdict,
+    confidencePercent: clamp(Math.round(parsed.confidencePercent), 0, 100),
+    estimatedCostCredits: Math.max(0, Math.round(parsed.estimatedCostCredits)),
+    estimatedEnergyKwh: Math.max(0, Math.round(parsed.estimatedEnergyKwh)),
+    estimatedDurationSols: Math.max(1, Math.round(parsed.estimatedDurationSols)),
+    risks: parsed.risks
+      .slice(0, 5)
+      .map((risk) => ({
+        level: risk.level,
+        category: normalizeModelText(risk.category, 48),
+        description: normalizeModelText(risk.description, 220),
+      }))
+      .filter((risk) => risk.category.length > 0 && risk.description.length > 0),
+    recommendations: parsed.recommendations
+      .slice(0, 4)
+      .map((item) => normalizeModelText(item, 180))
+      .filter((item) => item.length > 0),
+    summary: normalizeModelText(parsed.summary, 360),
+  };
 
-  return parsed;
+  if (
+    normalized.risks.length === 0 ||
+    normalized.recommendations.length === 0 ||
+    normalized.summary.length === 0
+  ) {
+    throw new Error("Model response missing required feasibility content");
+  }
+
+  return EstimateMissionFeasibilityResponse.parse(normalized);
 }
 
 function extractJson(text: string): string {
@@ -96,4 +120,13 @@ function extractJson(text: string): string {
 
 function clamp(n: number, lo: number, hi: number): number {
   return Math.min(hi, Math.max(lo, n));
+}
+
+function normalizeModelText(value: string, maxLength: number): string {
+  return value
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxLength);
 }

--- a/artifacts/api-server/src/lib/personaReply.ts
+++ b/artifacts/api-server/src/lib/personaReply.ts
@@ -38,11 +38,20 @@ Now stay in character.`;
       { role: "user", content: userMessage },
     ],
   }, { timeout: 20_000 });
-  const text = (response.choices[0]?.message?.content ?? "").trim();
+  const text = normalizePersonaText(response.choices[0]?.message?.content ?? "");
   return {
     text: text || "Comms degraded. Try again.",
     audioUrl: null,
     durationMs: Math.max(1200, Math.min(8000, text.length * 55)),
     voiceMocked: VOICE_MOCKED,
   };
+}
+
+function normalizePersonaText(value: string): string {
+  return value
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 280);
 }


### PR DESCRIPTION
## Summary
- add API boundary guardrails that block common jailbreak and abuse payloads on public AI inputs
- log blocked prompts with route, signal, and repeat-offender counts for abuse visibility
- tighten AI output handling by forcing JSON mode for feasibility responses and sanitizing model text before returning it

## Validation
- pnpm -C artifacts/api-server typecheck